### PR TITLE
[#158459529] Increase timeout in loggregator firehose test.

### DIFF
--- a/apps/loggregator.go
+++ b/apps/loggregator.go
@@ -105,7 +105,7 @@ var _ = AppsDescribe("loggregator", func() {
 				return helpers.CurlApp(Config, appName, fmt.Sprintf("/log/sleep/%d", hundredthOfOneSecond))
 			}, Config.DefaultTimeoutDuration()).Should(ContainSubstring("Muahaha"))
 
-			Eventually(msgChan, Config.DefaultTimeoutDuration()).Should(Receive(EnvelopeContainingMessageLike("Muahaha")), "To enable the logging & metrics firehose feature, please ask your CF administrator to add the 'doppler.firehose' scope to your CF admin user.")
+			Eventually(msgChan, 2*Config.DefaultTimeoutDuration()).Should(Receive(EnvelopeContainingMessageLike("Muahaha")), "To enable the logging & metrics firehose feature, please ask your CF administrator to add the 'doppler.firehose' scope to your CF admin user.")
 		})
 
 		It("shows container metrics", func() {


### PR DESCRIPTION
## What

We've seen this test failing intermittently. Increasing the timeout here
seems to resolve this. This also changes it to match the container
metrics test below which also uses `2*config.DefaultTimeoutDuration`, which was increased for similar issues in 1995884.

## How to review

Review along with https://github.com/alphagov/paas-cf/pull/1415

## Who can review

Not me.